### PR TITLE
add fileEncoding parameter

### DIFF
--- a/src/main/java/com/khubla/antlr/antlr4test/AntlrCaseInsensitiveFileStream.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/AntlrCaseInsensitiveFileStream.java
@@ -8,8 +8,8 @@ import org.antlr.v4.runtime.IntStream;
 public class AntlrCaseInsensitiveFileStream extends ANTLRFileStream {
    protected char[] lookaheadData;
 
-   public AntlrCaseInsensitiveFileStream(String fileName) throws IOException {
-      super(fileName);
+   public AntlrCaseInsensitiveFileStream(String fileName, String encoding) throws IOException {
+      super(fileName, encoding);
       lookaheadData = new char[data.length];
       for (int i = 0; i < data.length; i++) {
          lookaheadData[i] = Character.toLowerCase(data[i]);

--- a/src/main/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListener.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/AssertErrorsErrorListener.java
@@ -21,11 +21,11 @@ public class AssertErrorsErrorListener extends BaseErrorListener {
    protected static final String LITERAL_BACKSLASH_N = "\\\\n";
    protected List<String> errorMessages = new ArrayList<String>();
 
-   public void assertErrors(File errorMessagesFile) throws AssertErrorsException {
+   public void assertErrors(File errorMessagesFile, String encoding) throws AssertErrorsException {
       if (!errorMessages.isEmpty()) {
          List<String> expectedErrorMessages = null;
          try {
-            expectedErrorMessages = FileUtil.getNonEmptyLines(errorMessagesFile);
+            expectedErrorMessages = FileUtil.getNonEmptyLines(errorMessagesFile, encoding);
          } catch (final FileNotFoundException ex) {
             throw new AssertErrorsException(String.format("found %d errors, but missing file %s", errorMessages.size(), errorMessagesFile.getName()), ex);
          } catch (final IOException ex) {

--- a/src/main/java/com/khubla/antlr/antlr4test/FileUtil.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/FileUtil.java
@@ -28,8 +28,9 @@
 package com.khubla.antlr.antlr4test;
 
 import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.FileInputStream;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -76,23 +77,39 @@ public class FileUtil {
       }
    }
 
-   public static List<String> getNonEmptyLines(File file) throws IOException {
-      final List<String> nonEmptyLines = new ArrayList<String>();
-      BufferedReader br = null;
-      try {
-         br = new BufferedReader(new FileReader(file));
-         String line = br.readLine();
-         while (line != null) {
-            if (!"".equals(line.trim())) {
-               nonEmptyLines.add(line);
-            }
-            line = br.readLine();
-         }
-         return nonEmptyLines;
-      } finally {
-         if (br != null) {
-            br.close();
-         }
-      }
+   public static List<String> getNonEmptyLines(File file, String encoding) throws IOException {
+       final List<String> nonEmptyLines = new ArrayList<String>();
+       BufferedReader br = null;
+       InputStreamReader isr = null;
+       FileInputStream fis = null;
+       try {
+           fis = new FileInputStream(file);
+           try {
+               isr = new InputStreamReader(fis, encoding);
+               try {
+                   br = new BufferedReader(isr);
+                   String line = br.readLine();
+                   while (line != null) {
+                       if (!"".equals(line.trim())) {
+                           nonEmptyLines.add(line);
+                       }
+                       line = br.readLine();
+                   }
+                   return nonEmptyLines;
+               } finally {
+                   if (br != null) {
+                       br.close();
+                   }
+               }
+           } finally {
+               if (isr != null) {
+                   isr.close();
+               }
+           }
+       } finally {
+           if (fis != null) {
+               fis.close();
+           }
+       }
    }
 }

--- a/src/main/java/com/khubla/antlr/antlr4test/GrammarTestMojo.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/GrammarTestMojo.java
@@ -113,6 +113,11 @@ public class GrammarTestMojo extends AbstractMojo {
     */
    @Parameter(defaultValue = "${basedir}")
    private File baseDir;
+   /**
+    * file encoding
+    */
+   @Parameter(defaultValue = "UTF-8")
+   private String fileEncoding;
 
    /**
     * ctor
@@ -201,6 +206,10 @@ public class GrammarTestMojo extends AbstractMojo {
       return verbose;
    }
 
+   public String getFileEncoding() {
+       return fileEncoding;
+   }
+
    public void setBaseDir(File baseDir) {
       this.baseDir = baseDir;
    }
@@ -241,6 +250,10 @@ public class GrammarTestMojo extends AbstractMojo {
       this.verbose = verbose;
    }
 
+   public void setFileEncoding(String fileEncoding) {
+       this.fileEncoding = fileEncoding;
+   }
+
    /**
     * test a single grammar
     */
@@ -275,9 +288,9 @@ public class GrammarTestMojo extends AbstractMojo {
       System.out.println("Parsing :" + grammarFile.getAbsolutePath());
       ANTLRFileStream antlrFileStream;
       if (true == caseInsensitive) {
-         antlrFileStream = new AntlrCaseInsensitiveFileStream(grammarFile.getAbsolutePath());
+         antlrFileStream = new AntlrCaseInsensitiveFileStream(grammarFile.getAbsolutePath(), fileEncoding);
       } else {
-         antlrFileStream = new ANTLRFileStream(grammarFile.getAbsolutePath());
+         antlrFileStream = new ANTLRFileStream(grammarFile.getAbsolutePath(), fileEncoding);
       }
       final AssertErrorsErrorListener assertErrorsErrorListener = new AssertErrorsErrorListener();
       Lexer lexer = (Lexer) lexerConstructor.newInstance(antlrFileStream);
@@ -296,7 +309,7 @@ public class GrammarTestMojo extends AbstractMojo {
       parser.addErrorListener(assertErrorsErrorListener);
       final Method method = parserClass.getMethod(entryPoint);
       ParserRuleContext parserRuleContext = (ParserRuleContext) method.invoke(parser);
-      assertErrorsErrorListener.assertErrors(new File(grammarFile.getAbsolutePath() + ERRORS_SUFFIX));
+      assertErrorsErrorListener.assertErrors(new File(grammarFile.getAbsolutePath() + ERRORS_SUFFIX), fileEncoding);
       /*
        * show the tree
        */
@@ -311,7 +324,7 @@ public class GrammarTestMojo extends AbstractMojo {
       if (treeFile.exists()) {
          final String lispTree = Trees.toStringTree(parserRuleContext, parser);
          if (null != lispTree) {
-            final String treeFileData = FileUtils.fileRead(treeFile);
+            final String treeFileData = FileUtils.fileRead(treeFile, fileEncoding);
             if (null != treeFileData) {
                if (0 != treeFileData.compareTo(lispTree)) {
                   throw new Exception("Parse tree does not match '" + treeFile.getName() + "'");

--- a/src/test/java/test/com/khubla/antlr/antlr4test/TestGrammarTestMojo.java
+++ b/src/test/java/test/com/khubla/antlr/antlr4test/TestGrammarTestMojo.java
@@ -87,6 +87,7 @@ public class TestGrammarTestMojo extends AbstractMojoTestCase {
          final GrammarTestMojo grammarTestMojo = (GrammarTestMojo) lookupMojo(TEST_GOAL, pom);
          assertNotNull(grammarTestMojo);
          grammarTestMojo.setBaseDir(new File(getAbsolutePath("../..")).getCanonicalFile());
+         grammarTestMojo.setFileEncoding("UTF-8");
          grammarTestMojo.execute();
       } catch (final Exception e) {
          e.printStackTrace();
@@ -112,6 +113,7 @@ public class TestGrammarTestMojo extends AbstractMojoTestCase {
          final GrammarTestMojo grammarTestMojo = (GrammarTestMojo) lookupMojo(TEST_GOAL, pom);
          assertNotNull(grammarTestMojo);
          grammarTestMojo.setBaseDir(new File(getAbsolutePath("../..")).getCanonicalFile());
+         grammarTestMojo.setFileEncoding("UTF-8");
          grammarTestMojo.execute();
       } catch (final Exception e) {
          e.printStackTrace();


### PR DESCRIPTION
I want to set file encoding because I use Windows.
In Japanese version Windows, The `java.io.FileReader` uses Shift_JIS encoding instead of UTF-8.
So [this test](https://github.com/antlr/grammars-v4/blob/master/tsql/examples/full_width_chars.sql) is failed on Windows.