### PR TITLE
Support Unicode code points > U+FFFF with new CharStreams API

### DIFF
--- a/src/main/java/com/khubla/antlr/antlr4test/GrammarTestMojo.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/GrammarTestMojo.java
@@ -33,12 +33,13 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.Charset;
 import java.util.List;
 
 import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;
 
-import org.antlr.v4.runtime.ANTLRFileStream;
 import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.Parser;
@@ -288,11 +289,11 @@ public class GrammarTestMojo extends AbstractMojo {
       final Constructor<?> lexerConstructor = lexerClass.getConstructor(CharStream.class);
       final Constructor<?> parserConstructor = parserClass.getConstructor(TokenStream.class);
       System.out.println("Parsing :" + grammarFile.getAbsolutePath());
-      ANTLRFileStream antlrFileStream;
+      CharStream antlrFileStream;
       if (true == caseInsensitive) {
          antlrFileStream = new AntlrCaseInsensitiveFileStream(grammarFile.getAbsolutePath(), fileEncoding);
       } else {
-         antlrFileStream = new ANTLRFileStream(grammarFile.getAbsolutePath(), fileEncoding);
+        antlrFileStream = CharStreams.fromPath(grammarFile.toPath(), Charset.forName(fileEncoding));
       }
       final AssertErrorsErrorListener assertErrorsErrorListener = new AssertErrorsErrorListener();
       Lexer lexer = (Lexer) lexerConstructor.newInstance(antlrFileStream);


### PR DESCRIPTION
Currently, `antlr4test-maven-plugin` uses `ANTLRFileStream` to read input and convert to Unicode.

Unfortunately, this API doesn't support Unicode code points > `U+FFFF` (like emoji, e.g. 😀).

I fixed this in https://github.com/antlr/antlr4/issues/276 with a new API, part of ANTLR 4.7.

This diff uses the new `CharStreams` API to support the full range of Unicode code points in input files passed to `antlr4test-maven-plugin`.

I confirmed all the existing tests pass. I can add more if you'd like!