### PR TITLE
Include diff when tree comparison fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
 			<artifactId>plexus-utils</artifactId>
 			<version>3.0.22</version>
 		</dependency>
+		<dependency>
+			<groupId>org.bitbucket.cowwoc</groupId>
+			<artifactId>diff-match-patch</artifactId>
+			<version>1.1</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/com/khubla/antlr/antlr4test/GrammarTestMojo.java
+++ b/src/main/java/com/khubla/antlr/antlr4test/GrammarTestMojo.java
@@ -35,6 +35,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.List;
 
+import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;
+
 import org.antlr.v4.runtime.ANTLRFileStream;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -327,7 +329,17 @@ public class GrammarTestMojo extends AbstractMojo {
             final String treeFileData = FileUtils.fileRead(treeFile, fileEncoding);
             if (null != treeFileData) {
                if (0 != treeFileData.compareTo(lispTree)) {
-                  throw new Exception("Parse tree does not match '" + treeFile.getName() + "'");
+                  StringBuilder sb = new StringBuilder("Parse tree does not match '" + treeFile.getName() + "'. Differences: ");
+                  boolean first = false;
+                  for (DiffMatchPatch.Diff diff : new DiffMatchPatch().diffMain(treeFileData, lispTree)) {
+                     sb.append(diff.toString());
+                     if (first) {
+                        first = false;
+                     } else {
+                        sb.append(", ");
+                     }
+                  }
+                  throw new Exception(sb.toString());
                } else {
                   System.out.println("Parse tree for '" + grammarFile.getName() + "' matches '" + treeFile.getName() + "'");
                }


### PR DESCRIPTION
I had a hard time introducing `.tree` files to a `grammars-v4` test, because the error message when a tree doesn't match doesn't tell you what the mismatch is.

This diff uses https://bitbucket.org/cowwoc/google-diff-match-patch/wiki/Home to include a diff for when tree matches fail.